### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
   def index
-    
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
   def index
-    @items = Item.all
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -143,6 +143,7 @@
         <% end %>
       </li>
     <% end %>
+    <% if @items.blank? then %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -155,12 +156,13 @@
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
+            
             </div>
           </div>
         </div>
         <% end %>
       </li>
-     
+     <% end %>
     </ul>
   </div>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -118,11 +118,11 @@
     </div>
     <ul class='item-lists'>
 
-      
+     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>       <%# 商品が売れていればsold outを表示しましょう %>
+          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>       <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
@@ -130,10 +130,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -142,7 +142,7 @@
         </div>
         <% end %>
       </li>
-     
+    <% end %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>


### PR DESCRIPTION
WHAT
・商品一覧表示ページは、ログイン状況に関係なく、誰でも見ることができる
 ・出品されている商品が一覧で表示される
 ・画像が表示されており、画像がリンク切れなどにならない
 ・商品が出品されていない状態では、ダミーの商品情報が表示される
・ 左上から、出品された日時が新しい順に表示される
 ・商品出品時に登録した情報のうち、「画像・商品名・価格・配送料の負担」の4つの情報が、見本アプリと同様の形で表示される
 ・売却済みの商品は、画像上に「sold out」の文字が表示される

WHY
出品した商品を一覧表示させるため

商品のデータがある場合は、商品が一覧で表示されている動画
https://i.gyazo.com/a4fe412342dfcfa0bc055d928147627f.mp4